### PR TITLE
using array.join on getValues

### DIFF
--- a/src/pincode-component.ts
+++ b/src/pincode-component.ts
@@ -250,12 +250,12 @@ export class PincodeCmp {
 
   getValues(): string {
 
-    let values:string = '';
-    this.codeArr.forEach( (e) => {
-        e && (values += e.toString());
-    });
+    //let values:string = '';
+    //this.codeArr.forEach( (e) => {
+    //    e && (values += e.toString());
+    //});
 
-    return this.d.encoded(values);
+    return this.d.encoded(this.codeArr.join(''));
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
This fixes 0's in the code from being stripped out unintentionally, referenced in this issue

https://github.com/HsuanXyz/ionic2-pincode-input/issues/9

I also came across this issue and it's a simple fix in the `getValues()` method (commented the old code out to see what it previously was doing)

The looping was type checking the value it was iterating on and 0's are falsey so it was skipping those in the output.